### PR TITLE
Add build script for VS 2017 build tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bld/
 .vs/
 Sdk10Debug
 Sdk10Release
+nuget.exe
 
 OpenStackService/Release/
 HyperVNovaComputeSetup/Python27.wxs

--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -1,0 +1,8 @@
+#Sample script to build the solution with the target:`SDK10Release`
+#You need to have VS2017 build tools, and as a prerequisite you need to run
+#this script from a powershell which has VS2017 dev tools environment loaded
+$ErrorActionPreference = "Stop"
+$url = "https://dist.nuget.org/win-x86-commandline/v4.5.1/nuget.exe"
+Invoke-WebRequest $url -TimeoutSec 30 -DisableKeepAlive -OutFile ..\nuget.exe
+..\nuget.exe install .\packages.config -OutputDirectory packages
+MSBuild.exe /nologo /maxcpucount ..\OpenStackService.sln /target:Build /property:Configuration="SDK10Release" /p:Platform=x64


### PR DESCRIPTION
Add a sample Build.ps1 script in case VS2017 build tools installed.
This means nuget is not installed.
This script will download nuget version 4.5.1
download the required packages and build the solution for the SDK 14.1

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>