### PR TITLE
Add config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Beside just wrapping binaries the service wrapper has some interesting features:
 - `environment-file` environment file to be added to the given wrapped binary
 - `environment-file-pshell` environment file in powershell format to be added to the given wrapped binary
 - `exec-start-pre` command to be executed before starting the service
+- `service-command` service command line
+- `config` path to an ini file that may contain any of the above parameters.
 
 Simple example to wrap a binary:
 


### PR DESCRIPTION
It can be more convenient to have all the parameters set in config
files rather than passing them to the service wrapper.

Also, at the moment, it's impossible to pass a command to be
executed before running the service, containing whitespaces in the
binary path (e.g. --exec-start-pre="'some binary' 'some arg'").